### PR TITLE
Fixed non-POSIX Error with automake

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,8 @@ AC_PROG_CC
 AC_PROG_INSTALL
 AC_PROG_LN_S
 
++m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
+
 # Checks for libtool
 
 LT_INIT


### PR DESCRIPTION
Fixes the "/usr/share/automake-1.15/am/ltlibrary.am: warning: 'libdessert.la': linking libtool libraries using a non-POSIX" Error on automake.

Found Solution at https://github.com/DIGImend/hidrd/commit/56c09a4b1f9fc70a863e87a301f3e79dd7bf46aa
